### PR TITLE
Replace candlestick chart with SVG renderer

### DIFF
--- a/hooks/use-exchange.ts
+++ b/hooks/use-exchange.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useExchangeStore } from '@/lib/stores/exchange-store';
 import { useMarketStore } from '@/lib/stores/market-store';
 import { getExchangeAdapter } from '@/lib/exchanges';
@@ -12,6 +12,9 @@ export function useExchange() {
   const { setTicker, setOrderBook, addTrade, resetMarketData } =
     useMarketStore();
   const adapterRef = useRef<ExchangeAdapter | null>(null);
+  const [currentAdapter, setCurrentAdapter] = useState<ExchangeAdapter | null>(
+    null
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -19,6 +22,7 @@ export function useExchange() {
 
     const adapter = getExchangeAdapter(selectedExchange);
     adapterRef.current = adapter;
+    setCurrentAdapter(adapter);
     resetMarketData();
     setIsConnected(false);
 
@@ -74,6 +78,7 @@ export function useExchange() {
       adapterRef.current = null;
       setIsConnected(false);
       resetMarketData();
+      setCurrentAdapter((existing) => (existing === adapter ? null : existing));
     };
   }, [
     selectedExchange,
@@ -87,6 +92,6 @@ export function useExchange() {
   ]);
 
   return {
-    adapter: adapterRef.current,
+    adapter: currentAdapter,
   };
 }


### PR DESCRIPTION
## Summary
- replace the lightweight-charts dependency with a bespoke SVG candlestick renderer that works without external chart packages
- keep the chart responsive to container size, live ticker updates, and open position overlays so the trading view renders even when third-party modules are unavailable

## Testing
- npm run lint
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcaf866a28832eb671183b76c10822